### PR TITLE
25.10 development to main - fix polkit issue and housecleaning 

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,9 +1,20 @@
 ## CHANGELOGS
 
+## Mar 2025
+
+- Fixed policy kit issues preventing permission escalation
+- Added `rsync` to dependencies
+- Added missing pulseaudio-utils
+- Removed `JakooLit` ko-fi, etc
+- Updated package names
+- Script now does better checking for installed pkgs
+    - Prevents needless re-installation
+- Updated discord link
+
 ## Oct 2025
 
 - Added PPA to install Hyprland from packages
-- https://github.com/cpiber/hyprland-ppa
+    - https://github.com/cpiber/hyprland-ppa
 - No more building from source - but it remains a fallback option
 - Updated Hyprland packages should not be installed during normal updates
 

--- a/install-scripts/01-hypr-pkgs.sh
+++ b/install-scripts/01-hypr-pkgs.sh
@@ -30,6 +30,8 @@ hypr_package=(
     qt5ct
     qt5-style-kvantum
     qt5-style-kvantum-themes
+    qt-style-kvantum
+    qt6-style-kvantum
     qt6ct
     slurp
     swappy
@@ -59,6 +61,7 @@ hypr_package_2=(
     nvtop
     pamixer
     qalculate-gtk
+    xfce-polkit
 )
 
 # packages to force reinstall 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -97,8 +97,10 @@ packages=(
     "polkit-kde-agent-1" "polkit agent" "off"
     "imagemagick" "Image manipulation tool" "off"
     "kitty" "kitty-terminal" "off"
+    "qt-style-kvantum" "QT apps theming" "off"
     "qt5-style-kvantum" "QT apps theming" "off"
     "qt5-style-kvantum-themes" "QT apps theming" "off"
+    "qt6-style-kvantum" "QT apps theming" "off"
     "mousepad" "simple text editor" "off"
     "mpv" "multi-media player" "off"
     "mpv-mpris" "mpv-plugin" "off"
@@ -129,6 +131,7 @@ packages=(
     "yt-dlp" "video downloader" "off"
     "xarchiver" "Archive Manager" "off"
     "hyprland" "hyprland main package" "off"
+    "xfce-polkit" "polkit agent" "off"
 )
 
 # Define the list of directories to choose from (with options_command tags)


### PR DESCRIPTION
# Pull Request

## Description

#### 📅 **Updated: March 28th, 2026**

- Fixed policy kit issues preventing permission escalation
- Added `rsync` to dependencies
- Added missing pulseaudio-utils
- Removed `JakooLit` ko-fi, etc
- Updated package names
- Script now does better checking for installed pkgs
    - Prevents needless re-installation
- Updated discord link


 ## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
