### PR TITLE
26.04 development to main 

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -9,6 +9,11 @@
     - Set dark theme for whiptail fixes colors washed out on some terminals
         - Removed some duplicate colors
         - Fixed hight on OK/Cancel button
+    - `auto-install.sh`
+        - The script would got a git pull if Distro-Hyprland directory exsited
+        - If user started with JakooLit installer it would not get updated code
+        - Changed to remove `Distro-Hyprland` and do fresh git clone
+
 - Added:
     - `update-deps.sh` Install new dependencies since last install
         - You don't have to re-install everything, verifies you have all new deps

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -19,6 +19,7 @@
         - `dariogriffo/yazi-debian`
         - Up to date and has deb pkgs for all debian and ubuntu versions
         - Kept the original debian only repo as backup
+        - Checks for old versions of `yazi` removes if found
     - CLI File manager `yazi`
     - `update-deps.sh` Install new dependencies since last install
         - You don't have to re-install everything, verifies you have all new deps

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -3,6 +3,8 @@
 ## May 2026
 
 - Fixed:
+    - Linux Mint ID breaks `yazi.sh`
+        - Now checks for `UNBUNTU_CODENAME` as backup
     - Some scripts not executable
     - `libdisplay-info3` for 26.04
     - Link in `README.md`

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -15,6 +15,10 @@
         - Changed to remove `Distro-Hyprland` and do fresh git clone
 
 - Added:
+    - New GH repo for `yazi`
+        - `dariogriffo/yazi-debian`
+        - Up to date and has deb pkgs for all debian and ubuntu versions
+        - Kept the original debian only repo as backup
     - CLI File manager `yazi`
     - `update-deps.sh` Install new dependencies since last install
         - You don't have to re-install everything, verifies you have all new deps

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -15,6 +15,7 @@
         - Changed to remove `Distro-Hyprland` and do fresh git clone
 
 - Added:
+    - CLI File manager `yazi`
     - `update-deps.sh` Install new dependencies since last install
         - You don't have to re-install everything, verifies you have all new deps
         - If not it will install them

--- a/auto-install.sh
+++ b/auto-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/auto-install.sh
+++ b/auto-install.sh
@@ -42,9 +42,10 @@ fi
 printf "\n%.0s" {1..1}
 
 if [ -d "$Distro_DIR" ]; then
-    echo "${YELLOW}$Distro_DIR exists. Updating the repository... ${RESET}"
+    echo "${YELLOW}$Distro_DIR exists. Removing and performing a fresh clone... ${RESET}"
+    rm -rf "$Distro_DIR"
+    git clone --depth=1 -b "$Github_URL_Branch" "$Github_URL" "$Distro_DIR"
     cd "$Distro_DIR"
-    git stash && git pull
     chmod +x install.sh
     ./install.sh
 else

--- a/install-scripts/00-dependencies.sh
+++ b/install-scripts/00-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/01-hypr-pkgs.sh
+++ b/install-scripts/01-hypr-pkgs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings
@@ -19,6 +19,14 @@ Extra=(
 # packages needed
 hypr_package=(
     cliphist
+    ffmpeg
+    7zip
+    jq
+    poppler-utils
+    fd-find
+    ripgrep
+    fzf
+    zoxide
     fastfetch
     grim
     gvfs

--- a/install-scripts/02-pre-cleanup.sh
+++ b/install-scripts/02-pre-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/03-Final-Check.sh
+++ b/install-scripts/03-Final-Check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings
@@ -11,6 +11,13 @@
 
 packages=(
   imagemagick
+  7zip
+  fd-find
+  ffmpeg
+  fzf
+  jq
+  poppler-utils
+  ripgrep
   sway-notification-center
   waybar
   wl-clipboard
@@ -18,6 +25,8 @@ packages=(
   wlogout
   kitty
   hyprland
+  yazi
+  zoxide
 )
 
 # Binaries expected to be available (installed via PPA into /usr/bin)

--- a/install-scripts/Global_functions.sh
+++ b/install-scripts/Global_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/InputGroup.sh
+++ b/install-scripts/InputGroup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/ags.sh
+++ b/install-scripts/ags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/bluetooth.sh
+++ b/install-scripts/bluetooth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/dotfiles-branch.sh
+++ b/install-scripts/dotfiles-branch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/fonts.sh
+++ b/install-scripts/fonts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/gtk_themes.sh
+++ b/install-scripts/gtk_themes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/hypridle.sh
+++ b/install-scripts/hypridle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/hyprland-ppa-enable.sh
+++ b/install-scripts/hyprland-ppa-enable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/hyprland-ppa.sh
+++ b/install-scripts/hyprland-ppa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/hyprlock.sh
+++ b/install-scripts/hyprlock.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/ml4w-deps.sh
+++ b/install-scripts/ml4w-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/nvidia.sh
+++ b/install-scripts/nvidia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/quickshell.sh
+++ b/install-scripts/quickshell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/rofi-wayland.sh
+++ b/install-scripts/rofi-wayland.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/rog.sh
+++ b/install-scripts/rog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/sddm.sh
+++ b/install-scripts/sddm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/sddm_theme.sh
+++ b/install-scripts/sddm_theme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/swww.sh
+++ b/install-scripts/swww.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/thunar.sh
+++ b/install-scripts/thunar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/thunar_default.sh
+++ b/install-scripts/thunar_default.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/update-deps.sh
+++ b/install-scripts/update-deps.sh
@@ -20,6 +20,7 @@ Options:
 Env overrides:
   DEPENDENCIES_SCRIPT     Path to dependencies script
   PACKAGES_SCRIPT         Path to packages script
+  YAZI_SCRIPT             Path to yazi script
   CHECK_SCRIPT            Path to final check script
 EOF
 }
@@ -74,6 +75,7 @@ pick_script() {
 
 DEPENDENCIES_SCRIPT="${DEPENDENCIES_SCRIPT:-$(pick_script "dependencies" || pick_script "base")}"
 PACKAGES_SCRIPT="${PACKAGES_SCRIPT:-$(pick_script "hypr-pkgs" || pick_script "pkgs")}"
+YAZI_SCRIPT="${YAZI_SCRIPT:-$SCRIPT_DIR/yazi.sh}"
 CHECK_SCRIPT="${CHECK_SCRIPT:-$(pick_script "Final-Check" || pick_script "Final")}"
 PRE_CLEANUP_SCRIPT="$(pick_script "pre-cleanup" || true)"
 
@@ -83,6 +85,10 @@ if [ -n "$DEPENDENCIES_SCRIPT" ] && [ ! -f "$DEPENDENCIES_SCRIPT" ]; then
 fi
 if [ -n "$PACKAGES_SCRIPT" ] && [ ! -f "$PACKAGES_SCRIPT" ]; then
   echo "Script not found: $PACKAGES_SCRIPT"
+  exit 1
+fi
+if [ -n "$YAZI_SCRIPT" ] && [ ! -f "$YAZI_SCRIPT" ]; then
+  echo "Script not found: $YAZI_SCRIPT"
   exit 1
 fi
 if [ -n "$CHECK_SCRIPT" ] && [ ! -f "$CHECK_SCRIPT" ]; then
@@ -98,6 +104,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
   echo "Dry run. Scripts that would execute:"
   [ -n "$DEPENDENCIES_SCRIPT" ] && echo "  dependencies: $DEPENDENCIES_SCRIPT"
   [ -n "$PACKAGES_SCRIPT" ] && echo "  packages: $PACKAGES_SCRIPT"
+  [ -n "$YAZI_SCRIPT" ] && echo "  yazi: $YAZI_SCRIPT"
   [ "$INCLUDE_PRE_CLEANUP" -eq 1 ] && [ -n "$PRE_CLEANUP_SCRIPT" ] && echo "  pre-cleanup: $PRE_CLEANUP_SCRIPT"
   [ -n "$CHECK_SCRIPT" ] && echo "  final check: $CHECK_SCRIPT"
   exit 0
@@ -106,6 +113,7 @@ fi
 RUN_STAMP="$(date +%d-%H%M%S)"
 DEPENDENCIES_LOG="$LOG_DIR/update-deps-${RUN_STAMP}_dependencies.log"
 PACKAGES_LOG="$LOG_DIR/update-deps-${RUN_STAMP}_packages.log"
+YAZI_LOG="$LOG_DIR/update-deps-${RUN_STAMP}_yazi.log"
 PRE_CLEANUP_LOG="$LOG_DIR/update-deps-${RUN_STAMP}_pre-cleanup.log"
 CHECK_LOG="$LOG_DIR/update-deps-${RUN_STAMP}_check.log"
 
@@ -115,6 +123,7 @@ strip_ansi() {
 
 dependencies_status=0
 packages_status=0
+yazi_status=0
 pre_cleanup_status=0
 check_status=0
 
@@ -129,6 +138,13 @@ if [ -n "$PACKAGES_SCRIPT" ]; then
   echo "Running packages script: $(basename "$PACKAGES_SCRIPT")"
   bash "$PACKAGES_SCRIPT" 2>&1 | tee "$PACKAGES_LOG"
   packages_status=${PIPESTATUS[0]}
+fi
+
+if [ -n "$YAZI_SCRIPT" ]; then
+  echo
+  echo "Running yazi script: $(basename "$YAZI_SCRIPT")"
+  bash "$YAZI_SCRIPT" 2>&1 | tee "$YAZI_LOG"
+  yazi_status=${PIPESTATUS[0]}
 fi
 
 if [ "$INCLUDE_PRE_CLEANUP" -eq 1 ] && [ -n "$PRE_CLEANUP_SCRIPT" ]; then
@@ -147,6 +163,7 @@ fi
 
 clean_dependencies_log="$(mktemp)"
 clean_packages_log="$(mktemp)"
+clean_yazi_log="$(mktemp)"
 clean_check_log="$(mktemp)"
 if [ -f "$DEPENDENCIES_LOG" ]; then
   strip_ansi < "$DEPENDENCIES_LOG" > "$clean_dependencies_log"
@@ -154,12 +171,15 @@ fi
 if [ -f "$PACKAGES_LOG" ]; then
   strip_ansi < "$PACKAGES_LOG" > "$clean_packages_log"
 fi
+if [ -f "$YAZI_LOG" ]; then
+  strip_ansi < "$YAZI_LOG" > "$clean_yazi_log"
+fi
 if [ -f "$CHECK_LOG" ]; then
   strip_ansi < "$CHECK_LOG" > "$clean_check_log"
 fi
 
-mapfile -t installed_pkgs < <(awk '/\[OK\] Package /{print $3}' "$clean_packages_log" 2>/dev/null | sort -u)
-mapfile -t failed_pkgs < <(awk '/failed to install/{print $2}' "$clean_packages_log" 2>/dev/null | sort -u)
+mapfile -t installed_pkgs < <(cat "$clean_packages_log" "$clean_yazi_log" 2>/dev/null | awk '/\[OK\] Package /{print $3}' | sort -u)
+mapfile -t failed_pkgs < <(cat "$clean_packages_log" "$clean_yazi_log" 2>/dev/null | awk '/failed to install/{print $2}' | sort -u)
 
 latest_final_log="$(ls -t "$LOG_DIR"/00_CHECK-*_installed.log 2>/dev/null | head -n 1)"
 missing_pkgs=()
@@ -167,19 +187,21 @@ if [ -n "$latest_final_log" ] && [ -f "$latest_final_log" ]; then
   mapfile -t missing_pkgs < <(strip_ansi < "$latest_final_log" | awk 'NF==1')
 fi
 
-rm -f "$clean_dependencies_log" "$clean_packages_log" "$clean_check_log"
+rm -f "$clean_dependencies_log" "$clean_packages_log" "$clean_yazi_log" "$clean_check_log"
 
 echo
 echo "Summary"
 echo "-------"
 echo "Dependencies script: ${DEPENDENCIES_SCRIPT:-none}"
 echo "Packages script: ${PACKAGES_SCRIPT:-none}"
+echo "Yazi script: ${YAZI_SCRIPT:-none}"
 if [ "$INCLUDE_PRE_CLEANUP" -eq 1 ]; then
   echo "Pre-cleanup script: ${PRE_CLEANUP_SCRIPT:-none}"
 fi
 echo "Final check script: ${CHECK_SCRIPT:-none}"
 echo "Dependencies exit status: $dependencies_status"
 echo "Packages exit status: $packages_status"
+echo "Yazi exit status: $yazi_status"
 if [ "$INCLUDE_PRE_CLEANUP" -eq 1 ]; then
   echo "Pre-cleanup exit status: $pre_cleanup_status"
 fi

--- a/install-scripts/wallust.sh
+++ b/install-scripts/wallust.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/yazi.sh
+++ b/install-scripts/yazi.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ==================================================
+#  KoolDots (2026)
+#  Project URL: https://github.com/LinuxBeginnings
+#  License: GNU GPLv3
+#  SPDX-License-Identifier: GPL-3.0-or-later
+# ==================================================
+# 💫 https://github.com/LinuxBeginnings 💫 #
+# Yazi file manager install #
+
+YAZI_KEY_URL="https://debian.griffo.io/debian.griffo.io.key"
+YAZI_KEY_PATH="/etc/apt/trusted.gpg.d/yazi.asc"
+YAZI_REPO_FILE="/etc/apt/sources.list.d/yazi.list"
+YAZI_REPO_LINE="deb [signed-by=/etc/apt/trusted.gpg.d/yazi.asc] https://debian.griffo.io/debian stable main"
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || {
+    echo "${ERROR} Failed to change directory to $PARENT_DIR"
+    exit 1
+}
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+    echo "Failed to source Global_functions.sh"
+    exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_yazi.log"
+
+configure_yazi_repo() {
+    if [ "${DRY_RUN:-0}" = "1" ]; then
+        echo "[DRY-RUN] sudo wget -qO $YAZI_KEY_PATH $YAZI_KEY_URL" | tee -a "$LOG"
+        echo "[DRY-RUN] echo \"$YAZI_REPO_LINE\" | sudo tee $YAZI_REPO_FILE" | tee -a "$LOG"
+        echo "[DRY-RUN] sudo apt update" | tee -a "$LOG"
+        return 0
+    fi
+
+    echo "${INFO} Configuring ${YELLOW}Yazi${RESET} APT repository..." | tee -a "$LOG"
+    sudo wget -qO "$YAZI_KEY_PATH" "$YAZI_KEY_URL" 2>&1 | tee -a "$LOG"
+
+    if [ -f "$YAZI_REPO_FILE" ] && grep -Fxq "$YAZI_REPO_LINE" "$YAZI_REPO_FILE"; then
+        echo "${INFO} Yazi apt source already configured." | tee -a "$LOG"
+    else
+        printf '%s\n' "$YAZI_REPO_LINE" | sudo tee "$YAZI_REPO_FILE" >/dev/null
+        echo "${OK} Added Yazi apt source to ${YAZI_REPO_FILE}." | tee -a "$LOG"
+    fi
+
+    sudo apt update 2>&1 | tee -a "$LOG"
+}
+
+install_yazi_package() {
+    if [ "${DRY_RUN:-0}" = "1" ]; then
+        echo "[DRY-RUN] sudo apt-get -s install -y yazi" | tee -a "$LOG"
+        sudo apt-get -s install -y yazi >/dev/null || true
+        return 0
+    fi
+    install_package "yazi" "$LOG"
+}
+
+printf "\n%s - Installing ${SKY_BLUE}Yazi file manager${RESET}...\n" "${NOTE}"
+configure_yazi_repo
+install_yazi_package
+printf "\n%.0s" {1..1}

--- a/install-scripts/yazi.sh
+++ b/install-scripts/yazi.sh
@@ -38,6 +38,23 @@ SYSTEM_ARCH=""
 YAZI_RELEASE_TAG=""
 YAZI_ASSET_NAME=""
 YAZI_ASSET_URL=""
+cleanup_local_yazi_binaries() {
+    local local_bins=("/usr/local/bin/ya" "/usr/local/bin/yazi")
+    local bin_path=""
+
+    for bin_path in "${local_bins[@]}"; do
+        if [ -e "$bin_path" ]; then
+            if [ "${DRY_RUN:-0}" = "1" ]; then
+                echo "[DRY-RUN] sudo rm -f $bin_path" | tee -a "$LOG"
+            else
+                echo "${INFO} Removing conflicting local binary ${YELLOW}${bin_path}${RESET}..." | tee -a "$LOG"
+                if ! sudo rm -f "$bin_path" 2>&1 | tee -a "$LOG"; then
+                    echo "${WARN} Failed to remove ${bin_path}; it may shadow packaged yazi binaries." | tee -a "$LOG"
+                fi
+            fi
+        fi
+    done
+}
 
 detect_system_info() {
     if [ -r /etc/os-release ]; then
@@ -228,6 +245,7 @@ install_yazi_from_fallback_repo() {
 
 printf "\n%s - Installing ${SKY_BLUE}Yazi file manager${RESET}...\n" "${NOTE}"
 detect_system_info
+cleanup_local_yazi_binaries
 
 if ! install_yazi_from_github_release; then
     echo "${WARN} Falling back to debian.griffo.io apt repository for Yazi." | tee -a "$LOG"

--- a/install-scripts/yazi.sh
+++ b/install-scripts/yazi.sh
@@ -63,7 +63,12 @@ detect_system_info() {
     fi
 
     DISTRO_ID="${ID:-}"
-    DISTRO_CODENAME="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
+    if [ "$DISTRO_ID" = "linuxmint" ] && [ -n "${UBUNTU_CODENAME:-}" ]; then
+        DISTRO_ID="ubuntu"
+        DISTRO_CODENAME="${UBUNTU_CODENAME}"
+    else
+        DISTRO_CODENAME="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
+    fi
     if [ -z "$DISTRO_CODENAME" ] && command -v lsb_release >/dev/null 2>&1; then
         DISTRO_CODENAME="$(lsb_release -sc 2>/dev/null || true)"
     fi

--- a/install-scripts/yazi.sh
+++ b/install-scripts/yazi.sh
@@ -8,10 +8,10 @@
 # 💫 https://github.com/LinuxBeginnings 💫 #
 # Yazi file manager install #
 
-YAZI_KEY_URL="https://debian.griffo.io/debian.griffo.io.key"
-YAZI_KEY_PATH="/etc/apt/trusted.gpg.d/yazi.asc"
+YAZI_KEY_URL="https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc"
+YAZI_KEY_PATH="/etc/apt/trusted.gpg.d/debian.griffo.io.gpg"
 YAZI_REPO_FILE="/etc/apt/sources.list.d/yazi.list"
-YAZI_REPO_LINE="deb [signed-by=/etc/apt/trusted.gpg.d/yazi.asc] https://debian.griffo.io/debian stable main"
+YAZI_REPO_LINE="deb [signed-by=/etc/apt/trusted.gpg.d/debian.griffo.io.gpg] https://debian.griffo.io/apt noble main"
 
 ## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,14 +34,14 @@ LOG="Install-Logs/install-$(date +%d-%H%M%S)_yazi.log"
 
 configure_yazi_repo() {
     if [ "${DRY_RUN:-0}" = "1" ]; then
-        echo "[DRY-RUN] sudo wget -qO $YAZI_KEY_PATH $YAZI_KEY_URL" | tee -a "$LOG"
+        echo "[DRY-RUN] curl -sS $YAZI_KEY_URL | sudo gpg --dearmor --yes -o $YAZI_KEY_PATH" | tee -a "$LOG"
         echo "[DRY-RUN] echo \"$YAZI_REPO_LINE\" | sudo tee $YAZI_REPO_FILE" | tee -a "$LOG"
         echo "[DRY-RUN] sudo apt update" | tee -a "$LOG"
         return 0
     fi
 
     echo "${INFO} Configuring ${YELLOW}Yazi${RESET} APT repository..." | tee -a "$LOG"
-    sudo wget -qO "$YAZI_KEY_PATH" "$YAZI_KEY_URL" 2>&1 | tee -a "$LOG"
+    curl -sS "$YAZI_KEY_URL" | sudo gpg --dearmor --yes -o "$YAZI_KEY_PATH" 2>&1 | tee -a "$LOG"
 
     if [ -f "$YAZI_REPO_FILE" ] && grep -Fxq "$YAZI_REPO_LINE" "$YAZI_REPO_FILE"; then
         echo "${INFO} Yazi apt source already configured." | tee -a "$LOG"

--- a/install-scripts/yazi.sh
+++ b/install-scripts/yazi.sh
@@ -8,10 +8,11 @@
 # 💫 https://github.com/LinuxBeginnings 💫 #
 # Yazi file manager install #
 
+YAZI_GITHUB_RELEASE_API="https://api.github.com/repos/dariogriffo/yazi-debian/releases/latest"
 YAZI_KEY_URL="https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc"
 YAZI_KEY_PATH="/etc/apt/trusted.gpg.d/debian.griffo.io.gpg"
 YAZI_REPO_FILE="/etc/apt/sources.list.d/yazi.list"
-YAZI_REPO_LINE="deb [signed-by=/etc/apt/trusted.gpg.d/debian.griffo.io.gpg] https://debian.griffo.io/apt noble main"
+YAZI_POLICY_FILE="/etc/apt/preferences.d/yazi-prefer-github-release.pref"
 
 ## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,29 +32,192 @@ fi
 
 # Set the name of the log file to include the current date and time
 LOG="Install-Logs/install-$(date +%d-%H%M%S)_yazi.log"
+DISTRO_ID=""
+DISTRO_CODENAME=""
+SYSTEM_ARCH=""
+YAZI_RELEASE_TAG=""
+YAZI_ASSET_NAME=""
+YAZI_ASSET_URL=""
 
-configure_yazi_repo() {
+detect_system_info() {
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        source /etc/os-release
+    fi
+
+    DISTRO_ID="${ID:-}"
+    DISTRO_CODENAME="${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}"
+    if [ -z "$DISTRO_CODENAME" ] && command -v lsb_release >/dev/null 2>&1; then
+        DISTRO_CODENAME="$(lsb_release -sc 2>/dev/null || true)"
+    fi
+    SYSTEM_ARCH="$(dpkg --print-architecture 2>/dev/null || true)"
+}
+
+is_fallback_repo_enabled() {
+    grep -R "^[[:space:]]*deb .*debian\\.griffo\\.io/apt" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | grep -q .
+}
+
+select_release_asset() {
+    local release_json="$1"
+    local pattern=""
+
+    if [ "$DISTRO_ID" = "ubuntu" ]; then
+        pattern="\\+${DISTRO_CODENAME}_${SYSTEM_ARCH}_ubu\\.deb$"
+    elif [ "$DISTRO_ID" = "debian" ]; then
+        pattern="\\+${DISTRO_CODENAME}_${SYSTEM_ARCH}\\.deb$"
+    else
+        return 1
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+        YAZI_RELEASE_TAG="$(printf '%s' "$release_json" | jq -r '.tag_name // empty')"
+        YAZI_ASSET_URL="$(printf '%s' "$release_json" | jq -r --arg pattern "$pattern" '[.assets[] | select(.name | test($pattern)) | .browser_download_url] | first // empty')"
+        YAZI_ASSET_NAME="$(printf '%s' "$release_json" | jq -r --arg pattern "$pattern" '[.assets[] | select(.name | test($pattern)) | .name] | first // empty')"
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        local parsed=""
+        parsed="$(python3 -c '
+import json
+import sys
+
+distro = sys.argv[1]
+codename = sys.argv[2]
+arch = sys.argv[3]
+data = json.load(sys.stdin)
+tag = data.get("tag_name", "")
+
+if distro == "ubuntu":
+    suffix = f"+{codename}_{arch}_ubu.deb"
+elif distro == "debian":
+    suffix = f"+{codename}_{arch}.deb"
+else:
+    suffix = ""
+
+name = ""
+url = ""
+for asset in data.get("assets", []):
+    asset_name = asset.get("name", "")
+    if suffix and asset_name.endswith(suffix):
+        name = asset_name
+        url = asset.get("browser_download_url", "")
+        break
+
+print(f"{tag}\t{name}\t{url}")
+' "$DISTRO_ID" "$DISTRO_CODENAME" "$SYSTEM_ARCH" <<<"$release_json")" || return 1
+        IFS=$'\t' read -r YAZI_RELEASE_TAG YAZI_ASSET_NAME YAZI_ASSET_URL <<<"$parsed"
+        return 0
+    fi
+
+    return 1
+}
+
+set_preferred_yazi_policy() {
+    local pinned_version="$1"
+    [ -n "$pinned_version" ] || return 0
+
+    if [ "${DRY_RUN:-0}" = "1" ]; then
+        echo "[DRY-RUN] Configure $YAZI_POLICY_FILE to pin yazi version $pinned_version at priority 1001" | tee -a "$LOG"
+        return 0
+    fi
+
+    sudo tee "$YAZI_POLICY_FILE" >/dev/null <<EOF
+Package: yazi
+Pin: version $pinned_version
+Pin-Priority: 1001
+EOF
+    echo "${OK} Added apt policy pin for Yazi version ${YELLOW}${pinned_version}${RESET} in ${YAZI_POLICY_FILE}." | tee -a "$LOG"
+}
+
+install_yazi_from_github_release() {
+    local release_json=""
+    local tmp_dir=""
+    local deb_path=""
+    local deb_version=""
+
+    case "$DISTRO_ID" in
+        ubuntu|debian) ;;
+        *)
+            echo "${WARN} Unsupported distro ID '${DISTRO_ID:-unknown}' for yazi-debian release matching." | tee -a "$LOG"
+            return 1
+            ;;
+    esac
+
+    if [ -z "$DISTRO_CODENAME" ] || [ -z "$SYSTEM_ARCH" ]; then
+        echo "${WARN} Missing distro codename or architecture; cannot match yazi-debian release asset." | tee -a "$LOG"
+        return 1
+    fi
+
+    release_json="$(curl -fsSL "$YAZI_GITHUB_RELEASE_API" 2>>"$LOG")" || {
+        echo "${WARN} Failed to query latest yazi-debian GitHub release." | tee -a "$LOG"
+        return 1
+    }
+
+    if ! select_release_asset "$release_json"; then
+        echo "${WARN} Failed to parse GitHub release asset metadata." | tee -a "$LOG"
+        return 1
+    fi
+
+    if [ -z "$YAZI_ASSET_URL" ] || [ -z "$YAZI_ASSET_NAME" ]; then
+        echo "${WARN} No matching yazi-debian asset for ${DISTRO_ID}:${DISTRO_CODENAME} (${SYSTEM_ARCH})." | tee -a "$LOG"
+        return 1
+    fi
+
+    if [ "${DRY_RUN:-0}" = "1" ]; then
+        echo "[DRY-RUN] curl -fL \"$YAZI_ASSET_URL\" -o /tmp/$YAZI_ASSET_NAME" | tee -a "$LOG"
+        echo "[DRY-RUN] sudo apt-get install -y /tmp/$YAZI_ASSET_NAME" | tee -a "$LOG"
+        return 0
+    fi
+
+    echo "${INFO} Installing ${YELLOW}Yazi${RESET} from yazi-debian release ${YELLOW}${YAZI_RELEASE_TAG}${RESET} (${YAZI_ASSET_NAME})..." | tee -a "$LOG"
+
+    tmp_dir="$(mktemp -d)" || return 1
+    deb_path="$tmp_dir/$YAZI_ASSET_NAME"
+
+    if ! curl -fL "$YAZI_ASSET_URL" -o "$deb_path" 2>&1 | tee -a "$LOG"; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    if ! sudo apt-get install -y "$deb_path" 2>&1 | tee -a "$LOG"; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    deb_version="$(dpkg-deb -f "$deb_path" Version 2>/dev/null || true)"
+    rm -rf "$tmp_dir"
+
+    if is_fallback_repo_enabled; then
+        set_preferred_yazi_policy "$deb_version"
+    fi
+
+    return 0
+}
+
+configure_yazi_repo_fallback() {
+    local yazi_repo_line="deb [signed-by=$YAZI_KEY_PATH] https://debian.griffo.io/apt $DISTRO_CODENAME main"
     if [ "${DRY_RUN:-0}" = "1" ]; then
         echo "[DRY-RUN] curl -sS $YAZI_KEY_URL | sudo gpg --dearmor --yes -o $YAZI_KEY_PATH" | tee -a "$LOG"
-        echo "[DRY-RUN] echo \"$YAZI_REPO_LINE\" | sudo tee $YAZI_REPO_FILE" | tee -a "$LOG"
+        echo "[DRY-RUN] echo \"$yazi_repo_line\" | sudo tee $YAZI_REPO_FILE" | tee -a "$LOG"
         echo "[DRY-RUN] sudo apt update" | tee -a "$LOG"
         return 0
     fi
 
-    echo "${INFO} Configuring ${YELLOW}Yazi${RESET} APT repository..." | tee -a "$LOG"
+    echo "${INFO} Configuring ${YELLOW}Yazi${RESET} fallback APT repository for ${DISTRO_CODENAME}..." | tee -a "$LOG"
     curl -sS "$YAZI_KEY_URL" | sudo gpg --dearmor --yes -o "$YAZI_KEY_PATH" 2>&1 | tee -a "$LOG"
 
-    if [ -f "$YAZI_REPO_FILE" ] && grep -Fxq "$YAZI_REPO_LINE" "$YAZI_REPO_FILE"; then
+    if [ -f "$YAZI_REPO_FILE" ] && grep -Fxq "$yazi_repo_line" "$YAZI_REPO_FILE"; then
         echo "${INFO} Yazi apt source already configured." | tee -a "$LOG"
     else
-        printf '%s\n' "$YAZI_REPO_LINE" | sudo tee "$YAZI_REPO_FILE" >/dev/null
+        printf '%s\n' "$yazi_repo_line" | sudo tee "$YAZI_REPO_FILE" >/dev/null
         echo "${OK} Added Yazi apt source to ${YAZI_REPO_FILE}." | tee -a "$LOG"
     fi
 
     sudo apt update 2>&1 | tee -a "$LOG"
 }
 
-install_yazi_package() {
+install_yazi_from_fallback_repo() {
     if [ "${DRY_RUN:-0}" = "1" ]; then
         echo "[DRY-RUN] sudo apt-get -s install -y yazi" | tee -a "$LOG"
         sudo apt-get -s install -y yazi >/dev/null || true
@@ -63,6 +227,12 @@ install_yazi_package() {
 }
 
 printf "\n%s - Installing ${SKY_BLUE}Yazi file manager${RESET}...\n" "${NOTE}"
-configure_yazi_repo
-install_yazi_package
+detect_system_info
+
+if ! install_yazi_from_github_release; then
+    echo "${WARN} Falling back to debian.griffo.io apt repository for Yazi." | tee -a "$LOG"
+    configure_yazi_repo_fallback
+    install_yazi_from_fallback_repo
+fi
+
 printf "\n%.0s" {1..1}

--- a/install-scripts/zsh.sh
+++ b/install-scripts/zsh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install-scripts/zsh_pokemon.sh
+++ b/install-scripts/zsh_pokemon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings
@@ -468,6 +468,12 @@ sleep 1
 execute_script "hyprlock.sh"
 sleep 1
 execute_script "hypridle.sh"
+sleep 1
+echo "${INFO} Installing ${SKY_BLUE}Yazi file manager...${RESET}" | tee -a "$LOG"
+execute_script "yazi.sh" || {
+    echo "${ERROR:-[ERROR]} Yazi installation failed" | tee -a "$LOG"
+    exit 1
+}
 
 #execute_script "imagemagick.sh" #this is for compiling from source. 07 Sep 2024
 # execute_script "waybar-git.sh" only if waybar on repo is old

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ==================================================
 #  KoolDots (2026)
 #  Project URL: https://github.com/LinuxBeginnings


### PR DESCRIPTION
# Pull Request

## Description

### 📅 **Updated: Jun 5th, 2026**

 - Fixed:
    - Linux Mint ID breaks `yazi.sh`
        - Now checks for `UNBUNTU_CODENAME` as backup
    - Some scripts not executable
    - `libdisplay-info3` for 26.04
    - Link in `README.md`
    - Set dark theme for whiptail fixes colors washed out on some terminals
        - Removed some duplicate colors
        - Fixed hight on OK/Cancel button
    - `auto-install.sh`
        - The script would got a git pull if Distro-Hyprland directory existed
        - If user started with JakooLit installer it would not get updated code
        - Changed to remove `Distro-Hyprland` and do fresh git clone

- Added:
    - New GH repo for `yazi`
        - `dariogriffo/yazi-debian`
        - Up to date and has deb pkgs for all debian and ubuntu versions
        - Kept the original debian only repo as backup
        - Checks for old versions of `yazi` removes if found
    - CLI File manager `yazi`
    - `update-deps.sh` Install new dependencies since last install
        - You don't have to re-install everything, verifies you have all new deps
        - If not it will install them
    - `ddcutil` to support external monitor brightness
    - `socat` to fix `Tak0` scripts
    - `stylua` COPR for LUA support
    - Removed hyprland-qtutils not used anymore
    - Fixed `quickshell.sh` Missing `cpptrace` and other deps
    - Disabled `hyprland-qtuils` it's no longer used
    - Removed duplicate `hyprland-guituils`
 
## Type of change
 

- [x] **Bug fix** (non-breaking change which fixes an issue)
 
 
